### PR TITLE
Initial trace implementation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ language: go
 go:
   - 1.6
   - 1.5
-  - release
 
 before_install:
   - go get github.com/nbio/st

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: go
 go:
   - 1.6
   - 1.5
-  - tip
+  - release
 
 before_install:
   - go get github.com/nbio/st

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ go:
 before_install:
   - go get github.com/nbio/st
   - go get -u gopkg.in/vinxi/log.v0
+  - go get -u gopkg.in/Sirupsen/logrus.v0
   - go get -u -v github.com/axw/gocov/gocov
   - go get -u -v github.com/mattn/goveralls
   - go get -u -v github.com/golang/lint/golint

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # trace [![Build Status](https://travis-ci.org/vinxi/trace.png)](https://travis-ci.org/vinxi/trace) [![GoDoc](https://godoc.org/github.com/vinxi/trace?status.svg)](https://godoc.org/github.com/vinxi/trace) [![Coverage Status](https://coveralls.io/repos/github/vinxi/trace/badge.svg?branch=master)](https://coveralls.io/github/vinxi/trace?branch=master) [![Go Report Card](https://goreportcard.com/badge/github.com/vinxi/trace)](https://goreportcard.com/report/github.com/vinxi/trace)
 
-HTTP traffic tracing instrumnetation for your proxies. 
+Traffic tracing instrumentation for your proxies.  Designed to be extended to trace custom data or modify the request/response. 
+
+Relies on [log](https://github.com/vinxi/log) package to write structured traces and optionally send them via [hooks](https://github.com/Sirupsen/logrus#hooks) to different storage services.
 
 ## Installation
 
@@ -14,7 +16,7 @@ See [godoc](https://godoc.org/github.com/vinxi/trace) reference.
 
 ## Example
 
-#### Basic traffic tracing instrumentation
+#### Default tracing
 
 ```go
 package main
@@ -33,16 +35,9 @@ func main() {
   // Create a new vinxi proxy
   vs := vinxi.NewServer(vinxi.ServerOptions{Port: port})
 
-  // Plugin multiple middlewares writting some logs
-  vs.Use(func(w http.ResponseWriter, r *http.Request, h http.Handler) {
-    log.Info("[%s] %s", r.Method, r.RequestURI)
-    h.ServeHTTP(w, r)
-  })
-
-  vs.Use(func(w http.ResponseWriter, r *http.Request, h http.Handler) {
-    log.Warnf("%s", "foo bar")
-    h.ServeHTTP(w, r)
-  })
+  // Instrument the proxy with trace middleware 
+  // Now all the incoming traffic will be registered. 
+  vs.Use(trace.Default)
 
   // Target server to forward
   vs.Forward("http://httpbin.org")
@@ -53,7 +48,6 @@ func main() {
     fmt.Errorf("Error: %s\n", err)
   }
 }
-
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # trace [![Build Status](https://travis-ci.org/vinxi/trace.png)](https://travis-ci.org/vinxi/trace) [![GoDoc](https://godoc.org/github.com/vinxi/trace?status.svg)](https://godoc.org/github.com/vinxi/trace) [![Coverage Status](https://coveralls.io/repos/github/vinxi/trace/badge.svg?branch=master)](https://coveralls.io/github/vinxi/trace?branch=master) [![Go Report Card](https://goreportcard.com/badge/github.com/vinxi/trace)](https://goreportcard.com/report/github.com/vinxi/trace)
 
-Traffic tracing instrumentation for your proxies.  Designed to be extended to trace custom data or modify the request/response. 
+Traffic tracing instrumentation for your proxies. 
+Designed to be extended to trace custom data or modify the request/response. 
 
 Relies on [log](https://github.com/vinxi/log) package to write structured traces and optionally send them via [hooks](https://github.com/Sirupsen/logrus#hooks) to different storage services.
 

--- a/_examples/README.md
+++ b/_examples/README.md
@@ -1,0 +1,11 @@
+# Examples
+
+Run:
+```bash
+$ go run ./_examples/<name>/<file>.go
+```
+
+Example:
+```bash
+$ go run ./_examples/foo/bar.go
+```

--- a/_examples/default/default.go
+++ b/_examples/default/default.go
@@ -1,0 +1,29 @@
+package main
+
+import (
+	"fmt"
+	"net/http"
+
+	"gopkg.in/vinxi/trace.v0"
+	"gopkg.in/vinxi/vinxi.v0"
+)
+
+const port = 3100
+
+func main() {
+	// Create a new vinxi proxy
+	vs := vinxi.NewServer(vinxi.ServerOptions{Port: port})
+
+	// Instrument the proxy with trace middleware
+	// Now all the incoming traffic will be registered.
+	vs.Use(trace.Default)
+
+	// Target server to forward
+	vs.Forward("http://httpbin.org")
+
+	fmt.Printf("Server listening on port: %d\n", port)
+	err := vs.Listen()
+	if err != nil {
+		fmt.Errorf("Error: %s\n", err)
+	}
+}

--- a/trace.go
+++ b/trace.go
@@ -1,0 +1,123 @@
+// Package trace implements a featured and structured generic logger
+// interface designed to be used in core and third-party vinxi components.
+package trace
+
+import (
+	"io"
+	"net/http"
+	"sync"
+	"time"
+
+	logrus "gopkg.in/Sirupsen/logrus.v0"
+	"gopkg.in/vinxi/log.v0"
+)
+
+// TraceFunc represents the log trace function.
+type TraceFunc func(l log.Interface, w http.ResponseWriter, r *http.Request) log.Interface
+
+// mu provides thread synchronization for the public singleton API.
+var mu = sync.Mutex{}
+
+// Logger represents the standard default vinxi log based logger.
+var Logger = log.New()
+
+// Default tracer preconfigured instance for convenience.
+var Default = New()
+
+// init configures the logger instance.
+func init() {
+	SetFormatter(&logrus.JSONFormatter{})
+}
+
+// SetOutput sets the standard logger trace output.
+func SetOutput(out io.Writer) {
+	mu.Lock()
+	defer mu.Unlock()
+	Logger.Out = out
+}
+
+// SetFormatter sets the standard logger trace formatter.
+// Defaults to JSON formatter.
+func SetFormatter(formatter logrus.Formatter) {
+	mu.Lock()
+	defer mu.Unlock()
+	Logger.Formatter = formatter
+}
+
+// SetLevel sets the standard logger level.
+func SetLevel(level logrus.Level) {
+	mu.Lock()
+	defer mu.Unlock()
+	Logger.Level = level
+}
+
+// GetLevel returns the standard logger level.
+func GetLevel() logrus.Level {
+	mu.Lock()
+	defer mu.Unlock()
+	return Logger.Level
+}
+
+// AddHook adds a hook to the standard logger hooks.
+func AddHook(hook logrus.Hook) {
+	mu.Lock()
+	defer mu.Unlock()
+	Logger.Hooks.Add(hook)
+}
+
+// Tracer provides HTTP tracing capabilities to incoming traffic.
+type Tracer struct {
+	tracers []TraceFunc
+	logger  *logrus.Logger
+}
+
+// New creates a new Tracer with default settings.
+func New() *Tracer {
+	return &Tracer{
+		logger:  Logger,
+		tracers: []TraceFunc{TraceRequestInfo},
+	}
+}
+
+// AddTracer adds a new custom tracer function.
+func (t *Tracer) AddTracer(tracer ...TraceFunc) {
+	t.tracers = append(t.tracers, tracer...)
+}
+
+// SetTracer sets one or multiple tracer functions, removing the old ones.
+func (t *Tracer) SetTracer(tracers ...TraceFunc) {
+	t.tracers = tracers
+}
+
+// HandleHTTP read and report an incoming HTTP request.
+func (t *Tracer) HandleHTTP(w http.ResponseWriter, r *http.Request, h http.Handler) {
+	// Run tracer functions, chaining the logger across calls
+	var l log.Interface = t.logger
+	for _, tracer := range t.tracers {
+		if logger := tracer(l, w, r); logger != nil {
+			l = logger
+		}
+	}
+
+	// Continue with next middleware
+	h.ServeHTTP(w, r)
+}
+
+// TraceRequestInfo read request info and writes a structured trace entry into the default logger.
+func TraceRequestInfo(l log.Interface, w http.ResponseWriter, r *http.Request) log.Interface {
+	entry := logrus.NewEntry(Logger)
+	logger := entry.WithFields(logrus.Fields{
+		"protocol":      r.Proto,
+		"method":        r.Method,
+		"host":          r.Host,
+		"path":          r.RequestURI,
+		"ip":            r.RemoteAddr,
+		"headers":       r.Header,
+		"contentlength": r.ContentLength,
+		"time":          time.Now(),
+	})
+	logger.Message = "trace"
+	logger.Time = time.Now()
+	logger.Infof("%s %s [%s] - %s%s", r.Proto, r.Method, r.RemoteAddr, r.Host, r.RequestURI)
+	return logger
+}

--- a/trace.go
+++ b/trace.go
@@ -1,5 +1,5 @@
-// Package trace implements a featured and structured generic logger
-// interface designed to be used in core and third-party vinxi components.
+// Package trace implements a traffic tracing instrumentation for your proxies.
+// Designed to be extended to trace custom data or modify the request/response.
 package trace
 
 import (

--- a/trace.go
+++ b/trace.go
@@ -75,7 +75,7 @@ type Tracer struct {
 func New() *Tracer {
 	return &Tracer{
 		logger:  Logger,
-		tracers: []TracerFunc{DefaultTracer},
+		tracers: []TracerFunc{defaultTracer},
 	}
 }
 
@@ -103,9 +103,9 @@ func (t *Tracer) HandleHTTP(w http.ResponseWriter, r *http.Request, h http.Handl
 	h.ServeHTTP(w, r)
 }
 
-// DefaultTracer reads the request info and writes a structured data entry to the default logger.
+// defaultTracer reads the request info and writes a structured data entry to the default logger.
 // It's used as default tracer function. Returns an entry logger for subsequent writes.
-func DefaultTracer(l log.Interface, w http.ResponseWriter, r *http.Request) log.Interface {
+func defaultTracer(l log.Interface, w http.ResponseWriter, r *http.Request) log.Interface {
 	entry := logrus.NewEntry(Logger)
 	logger := entry.WithFields(logrus.Fields{
 		"protocol":      r.Proto,

--- a/trace_test.go
+++ b/trace_test.go
@@ -1,0 +1,55 @@
+package trace
+
+import (
+	"bytes"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/nbio/st"
+	log "gopkg.in/Sirupsen/logrus.v0"
+)
+
+func TestTrace(t *testing.T) {
+	var buffer bytes.Buffer
+	SetOutput(&buffer)
+	SetLevel(log.InfoLevel)
+	SetFormatter(&log.TextFormatter{DisableColors: true, DisableTimestamp: true, DisableSorting: true})
+
+	tracer := New()
+
+	headers := http.Header{"foo": []string{"bar"}}
+	req := &http.Request{
+		Proto:         "HTTP/1.1",
+		Method:        "GET",
+		Host:          "localhost",
+		RequestURI:    "/foo",
+		Header:        headers,
+		ContentLength: 10,
+		RemoteAddr:    "127.0.0.1:32131",
+	}
+
+	var called bool
+	tracer.HandleHTTP(nil, req, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+	}))
+
+	st.Expect(t, called, true)
+
+	entry := safeString(buffer)
+	st.Expect(t, strings.Contains(entry, "level=info"), true)
+	st.Expect(t, strings.Contains(entry, "GET [127.0.0.1:32131] -"), true)
+	st.Expect(t, strings.Contains(entry, "- localhost/foo\""), true)
+	st.Expect(t, strings.Contains(entry, "time="), true)
+	st.Expect(t, strings.Contains(entry, "protocol=\"HTTP/1.1\""), true)
+	st.Expect(t, strings.Contains(entry, "host=localhost"), true)
+	st.Expect(t, strings.Contains(entry, "path=\"/foo\""), true)
+	st.Expect(t, strings.Contains(entry, "ip=\"127.0.0.1:32131\""), true)
+	st.Expect(t, strings.Contains(entry, "headers=map[foo:[bar]]"), true)
+	st.Expect(t, strings.Contains(entry, "contentlength=10"), true)
+}
+
+func safeString(buf bytes.Buffer) string {
+	b := buf.Bytes()
+	return string(b[:len(b)-2])
+}


### PR DESCRIPTION
Take a look to the HTTP fields that are registered.
Also, not use if should use JSON as default formatter.  The trace output is be to `stdout`.

Trace log level is `info`. Perhaps we want to change or customize this.
